### PR TITLE
Update pxt.json

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "APA102": "github:waveshare/pxt-apa102#v1.0.0"
+        "APA102": "github:waveshareteam/pxt-apa102#v1.0.0"
     },
     "files": [
         "README.md",


### PR DESCRIPTION
Because the URL of the `Pxt-apa` package changed, it was not possible to add this extension to Makecode.